### PR TITLE
DE-49251: Context support in query parsing

### DIFF
--- a/examples/Car/QueryLanguage/CarBrandQueryLanguageField.php
+++ b/examples/Car/QueryLanguage/CarBrandQueryLanguageField.php
@@ -13,6 +13,7 @@ use BrandEmbassy\QueryLanguageParser\Operator\NotEqualTo\QueryLanguageFieldSuppo
 use BrandEmbassy\QueryLanguageParser\Operator\NotIn\QueryLanguageFieldSupportingNotInOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\NotLike\QueryLanguageFieldSupportingNotLikeOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\NotLike\QueryLanguageFieldSupportingNotLikeSymbolOperator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use BrandEmbassy\QueryLanguageParser\Value\MultipleValuesExpressionParserCreator;
 use BrandEmbassy\QueryLanguageParser\Value\StringValueParserCreator;
 use BrandEmbassy\QueryLanguageParser\Value\TextValueParserCreator;
@@ -93,49 +94,49 @@ final class CarBrandQueryLanguageField
     }
 
 
-    public function createEqualToOperatorOutput($fieldName, $value): CarBrandFilter
+    public function createEqualToOperatorOutput($fieldName, $value, QueryParserContext $context): CarBrandFilter
     {
         return new CarBrandFilter([$value]);
     }
 
 
-    public function createNotEqualToOperatorOutput($fieldName, $value): NotFilter
+    public function createNotEqualToOperatorOutput($fieldName, $value, QueryParserContext $context): NotFilter
     {
         return new NotFilter(new CarBrandFilter([$value]));
     }
 
 
-    public function createLikeOperatorOutput($fieldName, $value): CarBrandLikeFilter
+    public function createLikeOperatorOutput($fieldName, $value, QueryParserContext $context): CarBrandLikeFilter
     {
         return new CarBrandLikeFilter($value);
     }
 
 
-    public function createNotLikeOperatorOutput($fieldName, $value): NotFilter
+    public function createNotLikeOperatorOutput($fieldName, $value, QueryParserContext $context): NotFilter
     {
         return new NotFilter(new CarBrandLikeFilter($value));
     }
 
 
-    public function createLikeSymbolOperatorOutput($fieldName, $value)
+    public function createLikeSymbolOperatorOutput($fieldName, $value, QueryParserContext $context)
     {
-        return $this->createLikeOperatorOutput($fieldName, $value);
+        return $this->createLikeOperatorOutput($fieldName, $value, $context);
     }
 
 
-    public function createNotLikeSymbolOperatorOutput($fieldName, $value)
+    public function createNotLikeSymbolOperatorOutput($fieldName, $value, QueryParserContext $context)
     {
-        return $this->createNotLikeOperatorOutput($fieldName, $value);
+        return $this->createNotLikeOperatorOutput($fieldName, $value, $context);
     }
 
 
-    public function createInOperatorOutput($fieldName, array $values): CarBrandFilter
+    public function createInOperatorOutput($fieldName, array $values, QueryParserContext $context): CarBrandFilter
     {
         return new CarBrandFilter($values);
     }
 
 
-    public function createNotInOperatorOutput($fieldName, array $values): NotFilter
+    public function createNotInOperatorOutput($fieldName, array $values, QueryParserContext $context): NotFilter
     {
         return new NotFilter(new CarBrandFilter($values));
     }

--- a/examples/Car/QueryLanguage/CarColorQueryLanguageField.php
+++ b/examples/Car/QueryLanguage/CarColorQueryLanguageField.php
@@ -16,6 +16,7 @@ use BrandEmbassy\QueryLanguageParser\Operator\NotEqualTo\QueryLanguageFieldSuppo
 use BrandEmbassy\QueryLanguageParser\Operator\NotIn\QueryLanguageFieldSupportingNotInOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\NotLike\QueryLanguageFieldSupportingNotLikeOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\NotLike\QueryLanguageFieldSupportingNotLikeSymbolOperator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use BrandEmbassy\QueryLanguageParser\Value\MultipleValuesExpressionParserCreator;
 use BrandEmbassy\QueryLanguageParser\Value\StringValueParserCreator;
 use Ferno\Loco\GrammarException;
@@ -86,61 +87,61 @@ final class CarColorQueryLanguageField
     }
 
 
-    public function createEqualToOperatorOutput($fieldName, $value): CarColorFilter
+    public function createEqualToOperatorOutput($fieldName, $value, QueryParserContext $context): CarColorFilter
     {
         return new CarColorFilter([$value]);
     }
 
 
-    public function createNotEqualToOperatorOutput($fieldName, $value): NotFilter
+    public function createNotEqualToOperatorOutput($fieldName, $value, QueryParserContext $context): NotFilter
     {
         return new NotFilter(new CarColorFilter([$value]));
     }
 
 
-    public function createLikeOperatorOutput($fieldName, $value): CarColorLikeFilter
+    public function createLikeOperatorOutput($fieldName, $value, QueryParserContext $context): CarColorLikeFilter
     {
         return new CarColorLikeFilter($value);
     }
 
 
-    public function createNotLikeOperatorOutput($fieldName, $value): NotFilter
+    public function createNotLikeOperatorOutput($fieldName, $value, QueryParserContext $context): NotFilter
     {
         return new NotFilter(new CarColorLikeFilter($value));
     }
 
 
-    public function createLikeSymbolOperatorOutput($fieldName, $value)
+    public function createLikeSymbolOperatorOutput($fieldName, $value, QueryParserContext $context)
     {
-        return $this->createLikeOperatorOutput($fieldName, $value);
+        return $this->createLikeOperatorOutput($fieldName, $value, $context);
     }
 
 
-    public function createNotLikeSymbolOperatorOutput($fieldName, $value)
+    public function createNotLikeSymbolOperatorOutput($fieldName, $value, QueryParserContext $context)
     {
-        return $this->createNotLikeOperatorOutput($fieldName, $value);
+        return $this->createNotLikeOperatorOutput($fieldName, $value, $context);
     }
 
 
-    public function createInOperatorOutput($fieldName, array $values): CarColorFilter
+    public function createInOperatorOutput($fieldName, array $values, QueryParserContext $context): CarColorFilter
     {
         return new CarColorFilter($values);
     }
 
 
-    public function createNotInOperatorOutput($fieldName, array $values): NotFilter
+    public function createNotInOperatorOutput($fieldName, array $values, QueryParserContext $context): NotFilter
     {
         return new NotFilter(new CarColorFilter($values));
     }
 
 
-    public function createIsNullOperatorOutput($fieldName): NotFilter
+    public function createIsNullOperatorOutput($fieldName, QueryParserContext $context): NotFilter
     {
         return new NotFilter(new CarHasColorFilter());
     }
 
 
-    public function createIsNotNullOperatorOutput($fieldName): CarHasColorFilter
+    public function createIsNotNullOperatorOutput($fieldName, QueryParserContext $context): CarHasColorFilter
     {
         return new CarHasColorFilter();
     }

--- a/examples/Car/QueryLanguage/CarNumberOfDoorsQueryLanguageField.php
+++ b/examples/Car/QueryLanguage/CarNumberOfDoorsQueryLanguageField.php
@@ -16,6 +16,7 @@ use BrandEmbassy\QueryLanguageParser\Operator\LessThan\QueryLanguageFieldSupport
 use BrandEmbassy\QueryLanguageParser\Operator\LessThanOrEqualTo\QueryLanguageFieldSupportingLessThanOrEqualToOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\NotEqualTo\QueryLanguageFieldSupportingNotEqualToOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\NotIn\QueryLanguageFieldSupportingNotInOperator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use BrandEmbassy\QueryLanguageParser\Value\MultipleValuesExpressionParserCreator;
 use BrandEmbassy\QueryLanguageParser\Value\PositiveIntegerValueParserCreator;
 use Ferno\Loco\GrammarException;
@@ -84,25 +85,27 @@ final class CarNumberOfDoorsQueryLanguageField
     }
 
 
-    public function createEqualToOperatorOutput($fieldName, $value): CarNumberOfDoorsFilter
+    public function createEqualToOperatorOutput($fieldName, $value, QueryParserContext $context): CarNumberOfDoorsFilter
     {
-        return new CarNumberOfDoorsFilter([$value]);
+        $dynamicModifier = $context->get('number_of_doors_modifier') ?? 0;
+
+        return new CarNumberOfDoorsFilter([$value + $dynamicModifier]);
     }
 
 
-    public function createNotEqualToOperatorOutput($fieldName, $value): NotFilter
+    public function createNotEqualToOperatorOutput($fieldName, $value, QueryParserContext $context): NotFilter
     {
         return new NotFilter(new CarNumberOfDoorsFilter([$value]));
     }
 
 
-    public function createInOperatorOutput($fieldName, array $values): CarNumberOfDoorsFilter
+    public function createInOperatorOutput($fieldName, array $values, QueryParserContext $context): CarNumberOfDoorsFilter
     {
         return new CarNumberOfDoorsFilter($values);
     }
 
 
-    public function createNotInOperatorOutput($fieldName, array $values): NotFilter
+    public function createNotInOperatorOutput($fieldName, array $values, QueryParserContext $context): NotFilter
     {
         return new NotFilter(new CarNumberOfDoorsFilter($values));
     }
@@ -111,8 +114,11 @@ final class CarNumberOfDoorsQueryLanguageField
     /**
      * @inheritDoc
      */
-    public function createGreaterThanOperatorOutput($fieldName, $value): CarNumberOfDoorsGreaterThanFilter
-    {
+    public function createGreaterThanOperatorOutput(
+        $fieldName,
+        $value,
+        QueryParserContext $context
+    ): CarNumberOfDoorsGreaterThanFilter {
         return new CarNumberOfDoorsGreaterThanFilter($value);
     }
 
@@ -120,8 +126,11 @@ final class CarNumberOfDoorsQueryLanguageField
     /**
      * @inheritDoc
      */
-    public function createGreaterThanOrEqualToOperatorOutput($fieldName, $value): CarNumberOfDoorsGreaterThanOrEqualFilter
-    {
+    public function createGreaterThanOrEqualToOperatorOutput(
+        $fieldName,
+        $value,
+        QueryParserContext $context
+    ): CarNumberOfDoorsGreaterThanOrEqualFilter {
         return new CarNumberOfDoorsGreaterThanOrEqualFilter($value);
     }
 
@@ -129,8 +138,11 @@ final class CarNumberOfDoorsQueryLanguageField
     /**
      * @inheritDoc
      */
-    public function createLessThanOperatorOutput($fieldName, $value): CarNumberOfDoorsLessThanFilter
-    {
+    public function createLessThanOperatorOutput(
+        $fieldName,
+        $value,
+        QueryParserContext $context
+    ): CarNumberOfDoorsLessThanFilter {
         return new CarNumberOfDoorsLessThanFilter($value);
     }
 
@@ -138,8 +150,11 @@ final class CarNumberOfDoorsQueryLanguageField
     /**
      * @inheritDoc
      */
-    public function createLessThanOrEqualToOperatorOutput($fieldName, $value): CarNumberOfDoorsLessThanOrEqualFilter
-    {
+    public function createLessThanOrEqualToOperatorOutput(
+        $fieldName,
+        $value,
+        QueryParserContext $context
+    ): CarNumberOfDoorsLessThanOrEqualFilter {
         return new CarNumberOfDoorsLessThanOrEqualFilter($value);
     }
 }

--- a/src/Field/QueryLanguageFieldGrammarFactory.php
+++ b/src/Field/QueryLanguageFieldGrammarFactory.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Field;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageFieldSupportingMultipleValuesOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageFieldSupportingSingleValueOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use Ferno\Loco\GrammarException;
 use Ferno\Loco\LazyAltParser;
 use Ferno\Loco\MonoParser;
@@ -23,14 +24,17 @@ class QueryLanguageFieldGrammarFactory
      *
      * @throws GrammarException
      */
-    public function createParsers(QueryLanguageField $field, array $operators): array
-    {
+    public function createParsers(
+        QueryLanguageField $field,
+        array $operators,
+        QueryParserContext $context
+    ): array {
         $parsers = [$field->getFieldNameParserIdentifier() => $field->createFieldNameParser()];
 
         $valueParsers = $this->getValueParsers($field);
         $parsers = array_merge($parsers, $valueParsers);
 
-        $operatorParsers = $this->getOperatorParsers($field, $operators);
+        $operatorParsers = $this->getOperatorParsers($field, $operators, $context);
         $parsers = array_merge($parsers, $operatorParsers);
 
         $mainFieldParserIdentifier = $field->getFieldIdentifier();
@@ -65,14 +69,17 @@ class QueryLanguageFieldGrammarFactory
      *
      * @return MonoParser[]
      */
-    private function getOperatorParsers(QueryLanguageField $field, array $operators): array
-    {
+    private function getOperatorParsers(
+        QueryLanguageField $field,
+        array $operators,
+        QueryParserContext $context
+    ): array {
         $parsers = [];
 
         foreach ($operators as $operator) {
             if ($operator->isFieldSupported($field)) {
                 $parserIdentifier = $field->getFieldIdentifier() . '.' . $operator->getOperatorIdentifier();
-                $parsers[$parserIdentifier] = $operator->createFieldExpressionParser($field);
+                $parsers[$parserIdentifier] = $operator->createFieldExpressionParser($field, $context);
             }
         }
 

--- a/src/Grammar/QueryLanguageGrammarFactory.php
+++ b/src/Grammar/QueryLanguageGrammarFactory.php
@@ -6,6 +6,7 @@ use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageFieldGrammarFactory;
 use BrandEmbassy\QueryLanguageParser\LogicalOperatorOutputFactory;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use BrandEmbassy\QueryLanguageParser\Value\ValueOnlyFilterFactory;
 use BrandEmbassy\QueryLanguageParser\Value\ValueOnlyParserCreator;
 use Ferno\Loco\ConcParser;
@@ -47,6 +48,7 @@ class QueryLanguageGrammarFactory
     public function create(
         array $fields,
         array $operators,
+        QueryParserContext $context,
         ?ValueOnlyFilterFactory $valueOnlyFilterFactory = null
     ): Grammar {
         $basicParsers = [
@@ -165,7 +167,7 @@ class QueryLanguageGrammarFactory
 
         $fieldParsers = [];
         foreach ($fields as $field) {
-            $fieldParsers[] = $this->fieldGrammarFactory->createParsers($field, $operators);
+            $fieldParsers[] = $this->fieldGrammarFactory->createParsers($field, $operators, $context);
         }
 
         return new Grammar(

--- a/src/Operator/EqualTo/EqualToQueryLanguageOperator.php
+++ b/src/Operator/EqualTo/EqualToQueryLanguageOperator.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\EqualTo;
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperatorParserCreator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use Ferno\Loco\ConcParser;
 use Ferno\Loco\GrammarException;
 use Ferno\Loco\MonoParser;
@@ -39,7 +40,7 @@ class EqualToQueryLanguageOperator implements QueryLanguageOperator
     }
 
 
-    public function createFieldExpressionParser(QueryLanguageField $field): MonoParser
+    public function createFieldExpressionParser(QueryLanguageField $field, QueryParserContext $context): MonoParser
     {
         assert($field instanceof QueryLanguageFieldSupportingEqualToOperator);
 
@@ -49,7 +50,7 @@ class EqualToQueryLanguageOperator implements QueryLanguageOperator
                 self::OPERATOR_IDENTIFIER,
                 $field->getSingleValueParserIdentifier(),
             ],
-            static fn($identifier, $operator, $value) => $field->createEqualToOperatorOutput($identifier, $value),
+            static fn($identifier, $operator, $value) => $field->createEqualToOperatorOutput($identifier, $value, $context),
         );
     }
 }

--- a/src/Operator/EqualTo/EqualToQueryLanguageOperatorTest.php
+++ b/src/Operator/EqualTo/EqualToQueryLanguageOperatorTest.php
@@ -4,6 +4,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\EqualTo;
 
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarBrandFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\QueryLanguage\CarQueryParserFactory;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -23,7 +24,7 @@ class EqualToQueryLanguageOperatorTest extends TestCase
     {
         $parser = (new CarQueryParserFactory())->create();
 
-        $result = $parser->parse($query);
+        $result = $parser->parse($query, new QueryParserContext());
 
         assert($result instanceof CarBrandFilter);
         Assert::assertSame(['bmw'], $result->getBrands());

--- a/src/Operator/EqualTo/QueryLanguageFieldSupportingEqualToOperator.php
+++ b/src/Operator/EqualTo/QueryLanguageFieldSupportingEqualToOperator.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassy\QueryLanguageParser\Operator\EqualTo;
 
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageFieldSupportingSingleValueOperator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 
 interface QueryLanguageFieldSupportingEqualToOperator extends QueryLanguageFieldSupportingSingleValueOperator
 {
@@ -12,5 +13,5 @@ interface QueryLanguageFieldSupportingEqualToOperator extends QueryLanguageField
      *
      * @return mixed
      */
-    public function createEqualToOperatorOutput($fieldName, $value);
+    public function createEqualToOperatorOutput($fieldName, $value, QueryParserContext $context);
 }

--- a/src/Operator/GreaterThan/GreaterThanQueryLanguageOperator.php
+++ b/src/Operator/GreaterThan/GreaterThanQueryLanguageOperator.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\GreaterThan;
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperatorParserCreator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use Ferno\Loco\ConcParser;
 use Ferno\Loco\GrammarException;
 use Ferno\Loco\MonoParser;
@@ -39,7 +40,7 @@ class GreaterThanQueryLanguageOperator implements QueryLanguageOperator
     }
 
 
-    public function createFieldExpressionParser(QueryLanguageField $field): MonoParser
+    public function createFieldExpressionParser(QueryLanguageField $field, QueryParserContext $context): MonoParser
     {
         assert($field instanceof QueryLanguageFieldSupportingGreaterThanOperator);
 
@@ -49,7 +50,7 @@ class GreaterThanQueryLanguageOperator implements QueryLanguageOperator
                 self::OPERATOR_IDENTIFIER,
                 $field->getSingleValueParserIdentifier(),
             ],
-            static fn($identifier, $operator, $value) => $field->createGreaterThanOperatorOutput($identifier, $value),
+            static fn($identifier, $operator, $value) => $field->createGreaterThanOperatorOutput($identifier, $value, $context),
         );
     }
 }

--- a/src/Operator/GreaterThan/GreaterThanQueryLanguageOperatorTest.php
+++ b/src/Operator/GreaterThan/GreaterThanQueryLanguageOperatorTest.php
@@ -4,6 +4,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\GreaterThan;
 
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarNumberOfDoorsGreaterThanFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\QueryLanguage\CarQueryParserFactory;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -23,7 +24,7 @@ class GreaterThanQueryLanguageOperatorTest extends TestCase
     {
         $parser = (new CarQueryParserFactory())->create();
 
-        $result = $parser->parse($query);
+        $result = $parser->parse($query, new QueryParserContext());
 
         assert($result instanceof CarNumberOfDoorsGreaterThanFilter);
         Assert::assertSame(50, $result->getNumberOfDoors());

--- a/src/Operator/GreaterThan/QueryLanguageFieldSupportingGreaterThanOperator.php
+++ b/src/Operator/GreaterThan/QueryLanguageFieldSupportingGreaterThanOperator.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassy\QueryLanguageParser\Operator\GreaterThan;
 
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageFieldSupportingSingleValueOperator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 
 interface QueryLanguageFieldSupportingGreaterThanOperator extends QueryLanguageFieldSupportingSingleValueOperator
 {
@@ -12,5 +13,5 @@ interface QueryLanguageFieldSupportingGreaterThanOperator extends QueryLanguageF
      *
      * @return mixed
      */
-    public function createGreaterThanOperatorOutput($fieldName, $value);
+    public function createGreaterThanOperatorOutput($fieldName, $value, QueryParserContext $context);
 }

--- a/src/Operator/GreaterThanOrEqualTo/GreaterThanOrEqualToQueryLanguageOperator.php
+++ b/src/Operator/GreaterThanOrEqualTo/GreaterThanOrEqualToQueryLanguageOperator.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\GreaterThanOrEqualTo;
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperatorParserCreator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use Ferno\Loco\ConcParser;
 use Ferno\Loco\GrammarException;
 use Ferno\Loco\MonoParser;
@@ -39,7 +40,7 @@ class GreaterThanOrEqualToQueryLanguageOperator implements QueryLanguageOperator
     }
 
 
-    public function createFieldExpressionParser(QueryLanguageField $field): MonoParser
+    public function createFieldExpressionParser(QueryLanguageField $field, QueryParserContext $context): MonoParser
     {
         assert($field instanceof QueryLanguageFieldSupportingGreaterThanOrEqualToOperator);
 
@@ -49,7 +50,7 @@ class GreaterThanOrEqualToQueryLanguageOperator implements QueryLanguageOperator
                 self::OPERATOR_IDENTIFIER,
                 $field->getSingleValueParserIdentifier(),
             ],
-            static fn($identifier, $operator, $value) => $field->createGreaterThanOrEqualToOperatorOutput($identifier, $value),
+            static fn($identifier, $operator, $value) => $field->createGreaterThanOrEqualToOperatorOutput($identifier, $value, $context),
         );
     }
 }

--- a/src/Operator/GreaterThanOrEqualTo/GreaterThanOrEqualToQueryLanguageOperatorTest.php
+++ b/src/Operator/GreaterThanOrEqualTo/GreaterThanOrEqualToQueryLanguageOperatorTest.php
@@ -4,6 +4,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\GreaterThanOrEqualTo;
 
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarNumberOfDoorsGreaterThanOrEqualFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\QueryLanguage\CarQueryParserFactory;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -23,7 +24,7 @@ class GreaterThanOrEqualToQueryLanguageOperatorTest extends TestCase
     {
         $parser = (new CarQueryParserFactory())->create();
 
-        $result = $parser->parse($query);
+        $result = $parser->parse($query, new QueryParserContext());
 
         assert($result instanceof CarNumberOfDoorsGreaterThanOrEqualFilter);
         Assert::assertSame(50, $result->getNumberOfDoors());

--- a/src/Operator/GreaterThanOrEqualTo/QueryLanguageFieldSupportingGreaterThanOrEqualToOperator.php
+++ b/src/Operator/GreaterThanOrEqualTo/QueryLanguageFieldSupportingGreaterThanOrEqualToOperator.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassy\QueryLanguageParser\Operator\GreaterThanOrEqualTo;
 
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageFieldSupportingSingleValueOperator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 
 interface QueryLanguageFieldSupportingGreaterThanOrEqualToOperator extends QueryLanguageFieldSupportingSingleValueOperator
 {
@@ -12,5 +13,5 @@ interface QueryLanguageFieldSupportingGreaterThanOrEqualToOperator extends Query
      *
      * @return mixed
      */
-    public function createGreaterThanOrEqualToOperatorOutput($fieldName, $value);
+    public function createGreaterThanOrEqualToOperatorOutput($fieldName, $value, QueryParserContext $context);
 }

--- a/src/Operator/In/InQueryLanguageOperator.php
+++ b/src/Operator/In/InQueryLanguageOperator.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\In;
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperatorParserCreator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use Ferno\Loco\ConcParser;
 use Ferno\Loco\GrammarException;
 use Ferno\Loco\MonoParser;
@@ -39,7 +40,7 @@ class InQueryLanguageOperator implements QueryLanguageOperator
     }
 
 
-    public function createFieldExpressionParser(QueryLanguageField $field): MonoParser
+    public function createFieldExpressionParser(QueryLanguageField $field, QueryParserContext $context): MonoParser
     {
         assert($field instanceof QueryLanguageFieldSupportingInOperator);
 
@@ -49,7 +50,7 @@ class InQueryLanguageOperator implements QueryLanguageOperator
                 self::OPERATOR_IDENTIFIER,
                 $field->getMultipleValuesParserIdentifier(),
             ],
-            static fn($identifier, $operator, array $values) => $field->createInOperatorOutput($identifier, $values),
+            static fn($identifier, $operator, array $values) => $field->createInOperatorOutput($identifier, $values, $context),
         );
     }
 }

--- a/src/Operator/In/InQueryLanguageOperatorTest.php
+++ b/src/Operator/In/InQueryLanguageOperatorTest.php
@@ -4,6 +4,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\In;
 
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarBrandFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\QueryLanguage\CarQueryParserFactory;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -25,7 +26,7 @@ class InQueryLanguageOperatorTest extends TestCase
     {
         $parser = (new CarQueryParserFactory())->create();
 
-        $result = $parser->parse($query);
+        $result = $parser->parse($query, new QueryParserContext());
 
         assert($result instanceof CarBrandFilter);
         Assert::assertSame($expectedBrands, $result->getBrands());

--- a/src/Operator/In/QueryLanguageFieldSupportingInOperator.php
+++ b/src/Operator/In/QueryLanguageFieldSupportingInOperator.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassy\QueryLanguageParser\Operator\In;
 
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageFieldSupportingMultipleValuesOperator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 
 interface QueryLanguageFieldSupportingInOperator extends QueryLanguageFieldSupportingMultipleValuesOperator
 {
@@ -12,5 +13,5 @@ interface QueryLanguageFieldSupportingInOperator extends QueryLanguageFieldSuppo
      *
      * @return mixed
      */
-    public function createInOperatorOutput($fieldName, array $values);
+    public function createInOperatorOutput($fieldName, array $values, QueryParserContext $context);
 }

--- a/src/Operator/IsNotNull/IsNotNullQueryLanguageOperator.php
+++ b/src/Operator/IsNotNull/IsNotNullQueryLanguageOperator.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\IsNotNull;
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperatorParserCreator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use Ferno\Loco\ConcParser;
 use Ferno\Loco\GrammarException;
 use Ferno\Loco\MonoParser;
@@ -39,7 +40,7 @@ class IsNotNullQueryLanguageOperator implements QueryLanguageOperator
     }
 
 
-    public function createFieldExpressionParser(QueryLanguageField $field): MonoParser
+    public function createFieldExpressionParser(QueryLanguageField $field, QueryParserContext $context): MonoParser
     {
         assert($field instanceof QueryLanguageFieldSupportingIsNotNullOperator);
 
@@ -48,7 +49,7 @@ class IsNotNullQueryLanguageOperator implements QueryLanguageOperator
                 $field->getFieldNameParserIdentifier(),
                 self::OPERATOR_IDENTIFIER,
             ],
-            static fn($identifier, $operator) => $field->createIsNotNullOperatorOutput($identifier),
+            static fn($identifier, $operator) => $field->createIsNotNullOperatorOutput($identifier, $context),
         );
     }
 }

--- a/src/Operator/IsNotNull/IsNotNullQueryLanguageOperatorTest.php
+++ b/src/Operator/IsNotNull/IsNotNullQueryLanguageOperatorTest.php
@@ -4,6 +4,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\IsNotNull;
 
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarHasColorFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\QueryLanguage\CarQueryParserFactory;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -22,7 +23,7 @@ class IsNotNullQueryLanguageOperatorTest extends TestCase
     {
         $parser = (new CarQueryParserFactory())->create();
 
-        $result = $parser->parse($query);
+        $result = $parser->parse($query, new QueryParserContext());
 
         Assert::assertInstanceOf(CarHasColorFilter::class, $result);
     }

--- a/src/Operator/IsNotNull/QueryLanguageFieldSupportingIsNotNullOperator.php
+++ b/src/Operator/IsNotNull/QueryLanguageFieldSupportingIsNotNullOperator.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassy\QueryLanguageParser\Operator\IsNotNull;
 
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 
 interface QueryLanguageFieldSupportingIsNotNullOperator extends QueryLanguageField
 {
@@ -11,5 +12,5 @@ interface QueryLanguageFieldSupportingIsNotNullOperator extends QueryLanguageFie
      *
      * @return mixed
      */
-    public function createIsNotNullOperatorOutput($fieldName);
+    public function createIsNotNullOperatorOutput($fieldName, QueryParserContext $context);
 }

--- a/src/Operator/IsNull/IsNullQueryLanguageOperator.php
+++ b/src/Operator/IsNull/IsNullQueryLanguageOperator.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\IsNull;
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperatorParserCreator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use Ferno\Loco\ConcParser;
 use Ferno\Loco\GrammarException;
 use Ferno\Loco\MonoParser;
@@ -39,7 +40,7 @@ class IsNullQueryLanguageOperator implements QueryLanguageOperator
     }
 
 
-    public function createFieldExpressionParser(QueryLanguageField $field): MonoParser
+    public function createFieldExpressionParser(QueryLanguageField $field, QueryParserContext $context): MonoParser
     {
         assert($field instanceof QueryLanguageFieldSupportingIsNullOperator);
 
@@ -48,7 +49,7 @@ class IsNullQueryLanguageOperator implements QueryLanguageOperator
                 $field->getFieldNameParserIdentifier(),
                 self::OPERATOR_IDENTIFIER,
             ],
-            static fn($identifier, $operator) => $field->createIsNullOperatorOutput($identifier),
+            static fn($identifier, $operator) => $field->createIsNullOperatorOutput($identifier, $context),
         );
     }
 }

--- a/src/Operator/IsNull/IsNullQueryLanguageOperatorTest.php
+++ b/src/Operator/IsNull/IsNullQueryLanguageOperatorTest.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\IsNull;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarHasColorFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\NotFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\QueryLanguage\CarQueryParserFactory;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -24,7 +25,7 @@ class IsNullQueryLanguageOperatorTest extends TestCase
     {
         $parser = (new CarQueryParserFactory())->create();
 
-        $result = $parser->parse($query);
+        $result = $parser->parse($query, new QueryParserContext());
 
         assert($result instanceof NotFilter);
         Assert::assertInstanceOf(CarHasColorFilter::class, $result->getSubFilter());

--- a/src/Operator/IsNull/QueryLanguageFieldSupportingIsNullOperator.php
+++ b/src/Operator/IsNull/QueryLanguageFieldSupportingIsNullOperator.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassy\QueryLanguageParser\Operator\IsNull;
 
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 
 interface QueryLanguageFieldSupportingIsNullOperator extends QueryLanguageField
 {
@@ -11,5 +12,5 @@ interface QueryLanguageFieldSupportingIsNullOperator extends QueryLanguageField
      *
      * @return mixed
      */
-    public function createIsNullOperatorOutput($fieldName);
+    public function createIsNullOperatorOutput($fieldName, QueryParserContext $context);
 }

--- a/src/Operator/LessThan/LessThanQueryLanguageOperator.php
+++ b/src/Operator/LessThan/LessThanQueryLanguageOperator.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\LessThan;
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperatorParserCreator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use Ferno\Loco\ConcParser;
 use Ferno\Loco\GrammarException;
 use Ferno\Loco\MonoParser;
@@ -39,7 +40,7 @@ class LessThanQueryLanguageOperator implements QueryLanguageOperator
     }
 
 
-    public function createFieldExpressionParser(QueryLanguageField $field): MonoParser
+    public function createFieldExpressionParser(QueryLanguageField $field, QueryParserContext $context): MonoParser
     {
         assert($field instanceof QueryLanguageFieldSupportingLessThanOperator);
 
@@ -49,7 +50,7 @@ class LessThanQueryLanguageOperator implements QueryLanguageOperator
                 self::OPERATOR_IDENTIFIER,
                 $field->getSingleValueParserIdentifier(),
             ],
-            static fn($identifier, $operator, $value) => $field->createLessThanOperatorOutput($identifier, $value),
+            static fn($identifier, $operator, $value) => $field->createLessThanOperatorOutput($identifier, $value, $context),
         );
     }
 }

--- a/src/Operator/LessThan/LessThanQueryLanguageOperatorTest.php
+++ b/src/Operator/LessThan/LessThanQueryLanguageOperatorTest.php
@@ -4,6 +4,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\LessThan;
 
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarNumberOfDoorsLessThanFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\QueryLanguage\CarQueryParserFactory;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -23,7 +24,7 @@ class LessThanQueryLanguageOperatorTest extends TestCase
     {
         $parser = (new CarQueryParserFactory())->create();
 
-        $result = $parser->parse($query);
+        $result = $parser->parse($query, new QueryParserContext());
 
         assert($result instanceof CarNumberOfDoorsLessThanFilter);
         Assert::assertSame(50, $result->getNumberOfDoors());

--- a/src/Operator/LessThan/QueryLanguageFieldSupportingLessThanOperator.php
+++ b/src/Operator/LessThan/QueryLanguageFieldSupportingLessThanOperator.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassy\QueryLanguageParser\Operator\LessThan;
 
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageFieldSupportingSingleValueOperator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 
 interface QueryLanguageFieldSupportingLessThanOperator extends QueryLanguageFieldSupportingSingleValueOperator
 {
@@ -12,5 +13,5 @@ interface QueryLanguageFieldSupportingLessThanOperator extends QueryLanguageFiel
      *
      * @return mixed
      */
-    public function createLessThanOperatorOutput($fieldName, $value);
+    public function createLessThanOperatorOutput($fieldName, $value, QueryParserContext $context);
 }

--- a/src/Operator/LessThanOrEqualTo/LessThanOrEqualToQueryLanguageOperator.php
+++ b/src/Operator/LessThanOrEqualTo/LessThanOrEqualToQueryLanguageOperator.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\LessThanOrEqualTo;
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperatorParserCreator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use Ferno\Loco\ConcParser;
 use Ferno\Loco\GrammarException;
 use Ferno\Loco\MonoParser;
@@ -39,7 +40,7 @@ class LessThanOrEqualToQueryLanguageOperator implements QueryLanguageOperator
     }
 
 
-    public function createFieldExpressionParser(QueryLanguageField $field): MonoParser
+    public function createFieldExpressionParser(QueryLanguageField $field, QueryParserContext $context): MonoParser
     {
         assert($field instanceof QueryLanguageFieldSupportingLessThanOrEqualToOperator);
 
@@ -49,7 +50,7 @@ class LessThanOrEqualToQueryLanguageOperator implements QueryLanguageOperator
                 self::OPERATOR_IDENTIFIER,
                 $field->getSingleValueParserIdentifier(),
             ],
-            static fn($identifier, $operator, $value) => $field->createLessThanOrEqualToOperatorOutput($identifier, $value),
+            static fn($identifier, $operator, $value) => $field->createLessThanOrEqualToOperatorOutput($identifier, $value, $context),
         );
     }
 }

--- a/src/Operator/LessThanOrEqualTo/LessThanOrEqualToQueryLanguageOperatorTest.php
+++ b/src/Operator/LessThanOrEqualTo/LessThanOrEqualToQueryLanguageOperatorTest.php
@@ -4,6 +4,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\LessThanOrEqualTo;
 
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarNumberOfDoorsLessThanOrEqualFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\QueryLanguage\CarQueryParserFactory;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -23,7 +24,7 @@ class LessThanOrEqualToQueryLanguageOperatorTest extends TestCase
     {
         $parser = (new CarQueryParserFactory())->create();
 
-        $result = $parser->parse($query);
+        $result = $parser->parse($query, new QueryParserContext());
 
         assert($result instanceof CarNumberOfDoorsLessThanOrEqualFilter);
         Assert::assertSame(50, $result->getNumberOfDoors());

--- a/src/Operator/LessThanOrEqualTo/QueryLanguageFieldSupportingLessThanOrEqualToOperator.php
+++ b/src/Operator/LessThanOrEqualTo/QueryLanguageFieldSupportingLessThanOrEqualToOperator.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassy\QueryLanguageParser\Operator\LessThanOrEqualTo;
 
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageFieldSupportingSingleValueOperator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 
 interface QueryLanguageFieldSupportingLessThanOrEqualToOperator extends QueryLanguageFieldSupportingSingleValueOperator
 {
@@ -12,5 +13,5 @@ interface QueryLanguageFieldSupportingLessThanOrEqualToOperator extends QueryLan
      *
      * @return mixed
      */
-    public function createLessThanOrEqualToOperatorOutput($fieldName, $value);
+    public function createLessThanOrEqualToOperatorOutput($fieldName, $value, QueryParserContext $context);
 }

--- a/src/Operator/Like/LikeQueryLanguageOperator.php
+++ b/src/Operator/Like/LikeQueryLanguageOperator.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\Like;
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperatorParserCreator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use Ferno\Loco\ConcParser;
 use Ferno\Loco\GrammarException;
 use Ferno\Loco\MonoParser;
@@ -39,7 +40,7 @@ class LikeQueryLanguageOperator implements QueryLanguageOperator
     }
 
 
-    public function createFieldExpressionParser(QueryLanguageField $field): MonoParser
+    public function createFieldExpressionParser(QueryLanguageField $field, QueryParserContext $context): MonoParser
     {
         assert($field instanceof QueryLanguageFieldSupportingLikeOperator);
 
@@ -49,7 +50,7 @@ class LikeQueryLanguageOperator implements QueryLanguageOperator
                 self::OPERATOR_IDENTIFIER,
                 $field->getSingleValueParserIdentifier(),
             ],
-            static fn($identifier, $operator, $value) => $field->createLikeOperatorOutput($identifier, $value),
+            static fn($identifier, $operator, $value) => $field->createLikeOperatorOutput($identifier, $value, $context),
         );
     }
 }

--- a/src/Operator/Like/LikeQueryLanguageOperatorTest.php
+++ b/src/Operator/Like/LikeQueryLanguageOperatorTest.php
@@ -4,6 +4,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\Like;
 
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarBrandLikeFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\QueryLanguage\CarQueryParserFactory;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use BrandEmbassy\QueryLanguageParser\UnableToParseQueryException;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
@@ -24,7 +25,7 @@ class LikeQueryLanguageOperatorTest extends TestCase
     {
         $parser = (new CarQueryParserFactory())->create();
 
-        $result = $parser->parse($query);
+        $result = $parser->parse($query, new QueryParserContext());
 
         assert($result instanceof CarBrandLikeFilter);
         Assert::assertSame('bmw', $result->getBrand());
@@ -51,7 +52,7 @@ class LikeQueryLanguageOperatorTest extends TestCase
         $parser = (new CarQueryParserFactory())->create();
 
         $this->expectException(UnableToParseQueryException::class);
-        $parser->parse($query);
+        $parser->parse($query, new QueryParserContext());
     }
 
 

--- a/src/Operator/Like/LikeSymbolQueryLanguageOperator.php
+++ b/src/Operator/Like/LikeSymbolQueryLanguageOperator.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\Like;
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperatorParserCreator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use Ferno\Loco\ConcParser;
 use Ferno\Loco\GrammarException;
 use Ferno\Loco\MonoParser;
@@ -39,7 +40,7 @@ class LikeSymbolQueryLanguageOperator implements QueryLanguageOperator
     }
 
 
-    public function createFieldExpressionParser(QueryLanguageField $field): MonoParser
+    public function createFieldExpressionParser(QueryLanguageField $field, QueryParserContext $context): MonoParser
     {
         assert($field instanceof QueryLanguageFieldSupportingLikeSymbolOperator);
 
@@ -49,7 +50,7 @@ class LikeSymbolQueryLanguageOperator implements QueryLanguageOperator
                 self::OPERATOR_IDENTIFIER,
                 $field->getSingleValueParserIdentifier(),
             ],
-            static fn($identifier, $operator, $value) => $field->createLikeSymbolOperatorOutput($identifier, $value),
+            static fn($identifier, $operator, $value) => $field->createLikeSymbolOperatorOutput($identifier, $value, $context),
         );
     }
 }

--- a/src/Operator/Like/LikeSymbolQueryLanguageOperatorTest.php
+++ b/src/Operator/Like/LikeSymbolQueryLanguageOperatorTest.php
@@ -4,6 +4,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\Like;
 
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarBrandLikeFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\QueryLanguage\CarQueryParserFactory;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -23,7 +24,7 @@ class LikeSymbolQueryLanguageOperatorTest extends TestCase
     {
         $parser = (new CarQueryParserFactory())->create();
 
-        $result = $parser->parse($query);
+        $result = $parser->parse($query, new QueryParserContext());
 
         assert($result instanceof CarBrandLikeFilter);
         Assert::assertSame('bmw', $result->getBrand());

--- a/src/Operator/Like/QueryLanguageFieldSupportingLikeOperator.php
+++ b/src/Operator/Like/QueryLanguageFieldSupportingLikeOperator.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassy\QueryLanguageParser\Operator\Like;
 
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageFieldSupportingSingleValueOperator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 
 interface QueryLanguageFieldSupportingLikeOperator extends QueryLanguageFieldSupportingSingleValueOperator
 {
@@ -12,5 +13,5 @@ interface QueryLanguageFieldSupportingLikeOperator extends QueryLanguageFieldSup
      *
      * @return mixed
      */
-    public function createLikeOperatorOutput($fieldName, $value);
+    public function createLikeOperatorOutput($fieldName, $value, QueryParserContext $context);
 }

--- a/src/Operator/Like/QueryLanguageFieldSupportingLikeSymbolOperator.php
+++ b/src/Operator/Like/QueryLanguageFieldSupportingLikeSymbolOperator.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassy\QueryLanguageParser\Operator\Like;
 
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageFieldSupportingSingleValueOperator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 
 interface QueryLanguageFieldSupportingLikeSymbolOperator extends QueryLanguageFieldSupportingSingleValueOperator
 {
@@ -12,5 +13,5 @@ interface QueryLanguageFieldSupportingLikeSymbolOperator extends QueryLanguageFi
      *
      * @return mixed
      */
-    public function createLikeSymbolOperatorOutput($fieldName, $value);
+    public function createLikeSymbolOperatorOutput($fieldName, $value, QueryParserContext $context);
 }

--- a/src/Operator/NotEqualTo/NotEqualToQueryLanguageOperator.php
+++ b/src/Operator/NotEqualTo/NotEqualToQueryLanguageOperator.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\NotEqualTo;
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperatorParserCreator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use Ferno\Loco\ConcParser;
 use Ferno\Loco\GrammarException;
 use Ferno\Loco\MonoParser;
@@ -39,7 +40,7 @@ class NotEqualToQueryLanguageOperator implements QueryLanguageOperator
     }
 
 
-    public function createFieldExpressionParser(QueryLanguageField $field): MonoParser
+    public function createFieldExpressionParser(QueryLanguageField $field, QueryParserContext $context): MonoParser
     {
         assert($field instanceof QueryLanguageFieldSupportingNotEqualToOperator);
 
@@ -49,7 +50,7 @@ class NotEqualToQueryLanguageOperator implements QueryLanguageOperator
                 self::OPERATOR_IDENTIFIER,
                 $field->getSingleValueParserIdentifier(),
             ],
-            static fn($identifier, $operator, $value) => $field->createNotEqualToOperatorOutput($identifier, $value),
+            static fn($identifier, $operator, $value) => $field->createNotEqualToOperatorOutput($identifier, $value, $context),
         );
     }
 }

--- a/src/Operator/NotEqualTo/NotEqualToQueryLanguageOperatorTest.php
+++ b/src/Operator/NotEqualTo/NotEqualToQueryLanguageOperatorTest.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\NotEqualTo;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarBrandFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\NotFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\QueryLanguage\CarQueryParserFactory;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -24,7 +25,7 @@ class NotEqualToQueryLanguageOperatorTest extends TestCase
     {
         $parser = (new CarQueryParserFactory())->create();
 
-        $result = $parser->parse($query);
+        $result = $parser->parse($query, new QueryParserContext());
 
         assert($result instanceof NotFilter);
 

--- a/src/Operator/NotEqualTo/QueryLanguageFieldSupportingNotEqualToOperator.php
+++ b/src/Operator/NotEqualTo/QueryLanguageFieldSupportingNotEqualToOperator.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassy\QueryLanguageParser\Operator\NotEqualTo;
 
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageFieldSupportingSingleValueOperator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 
 interface QueryLanguageFieldSupportingNotEqualToOperator extends QueryLanguageFieldSupportingSingleValueOperator
 {
@@ -12,5 +13,5 @@ interface QueryLanguageFieldSupportingNotEqualToOperator extends QueryLanguageFi
      *
      * @return mixed
      */
-    public function createNotEqualToOperatorOutput($fieldName, $value);
+    public function createNotEqualToOperatorOutput($fieldName, $value, QueryParserContext $context);
 }

--- a/src/Operator/NotIn/NotInQueryLanguageOperator.php
+++ b/src/Operator/NotIn/NotInQueryLanguageOperator.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\NotIn;
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperatorParserCreator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use Ferno\Loco\ConcParser;
 use Ferno\Loco\GrammarException;
 use Ferno\Loco\MonoParser;
@@ -39,7 +40,7 @@ class NotInQueryLanguageOperator implements QueryLanguageOperator
     }
 
 
-    public function createFieldExpressionParser(QueryLanguageField $field): MonoParser
+    public function createFieldExpressionParser(QueryLanguageField $field, QueryParserContext $context): MonoParser
     {
         assert($field instanceof QueryLanguageFieldSupportingNotInOperator);
 
@@ -49,7 +50,7 @@ class NotInQueryLanguageOperator implements QueryLanguageOperator
                 self::OPERATOR_IDENTIFIER,
                 $field->getMultipleValuesParserIdentifier(),
             ],
-            static fn($identifier, $operator, array $values) => $field->createNotInOperatorOutput($identifier, $values),
+            static fn($identifier, $operator, array $values) => $field->createNotInOperatorOutput($identifier, $values, $context),
         );
     }
 }

--- a/src/Operator/NotIn/NotInQueryLanguageOperatorTest.php
+++ b/src/Operator/NotIn/NotInQueryLanguageOperatorTest.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\NotIn;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarBrandFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\NotFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\QueryLanguage\CarQueryParserFactory;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -26,7 +27,7 @@ class NotInQueryLanguageOperatorTest extends TestCase
     {
         $parser = (new CarQueryParserFactory())->create();
 
-        $result = $parser->parse($query);
+        $result = $parser->parse($query, new QueryParserContext());
 
         assert($result instanceof NotFilter);
         $subFilter = $result->getSubFilter();

--- a/src/Operator/NotIn/QueryLanguageFieldSupportingNotInOperator.php
+++ b/src/Operator/NotIn/QueryLanguageFieldSupportingNotInOperator.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassy\QueryLanguageParser\Operator\NotIn;
 
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageFieldSupportingMultipleValuesOperator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 
 interface QueryLanguageFieldSupportingNotInOperator extends QueryLanguageFieldSupportingMultipleValuesOperator
 {
@@ -12,5 +13,5 @@ interface QueryLanguageFieldSupportingNotInOperator extends QueryLanguageFieldSu
      *
      * @return mixed
      */
-    public function createNotInOperatorOutput($fieldName, array $values);
+    public function createNotInOperatorOutput($fieldName, array $values, QueryParserContext $context);
 }

--- a/src/Operator/NotLike/NotLikeQueryLanguageOperator.php
+++ b/src/Operator/NotLike/NotLikeQueryLanguageOperator.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\NotLike;
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperatorParserCreator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use Ferno\Loco\ConcParser;
 use Ferno\Loco\GrammarException;
 use Ferno\Loco\MonoParser;
@@ -39,7 +40,7 @@ class NotLikeQueryLanguageOperator implements QueryLanguageOperator
     }
 
 
-    public function createFieldExpressionParser(QueryLanguageField $field): MonoParser
+    public function createFieldExpressionParser(QueryLanguageField $field, QueryParserContext $context): MonoParser
     {
         assert($field instanceof QueryLanguageFieldSupportingNotLikeOperator);
 
@@ -49,7 +50,7 @@ class NotLikeQueryLanguageOperator implements QueryLanguageOperator
                 self::OPERATOR_IDENTIFIER,
                 $field->getSingleValueParserIdentifier(),
             ],
-            static fn($identifier, $operator, $value) => $field->createNotLikeOperatorOutput($identifier, $value),
+            static fn($identifier, $operator, $value) => $field->createNotLikeOperatorOutput($identifier, $value, $context),
         );
     }
 }

--- a/src/Operator/NotLike/NotLikeQueryLanguageOperatorTest.php
+++ b/src/Operator/NotLike/NotLikeQueryLanguageOperatorTest.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\NotLike;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarBrandLikeFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\NotFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\QueryLanguage\CarQueryParserFactory;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use BrandEmbassy\QueryLanguageParser\UnableToParseQueryException;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
@@ -25,7 +26,7 @@ class NotLikeQueryLanguageOperatorTest extends TestCase
     {
         $parser = (new CarQueryParserFactory())->create();
 
-        $result = $parser->parse($query);
+        $result = $parser->parse($query, new QueryParserContext());
 
         assert($result instanceof NotFilter);
 
@@ -55,7 +56,7 @@ class NotLikeQueryLanguageOperatorTest extends TestCase
         $parser = (new CarQueryParserFactory())->create();
 
         $this->expectException(UnableToParseQueryException::class);
-        $parser->parse($query);
+        $parser->parse($query, new QueryParserContext());
     }
 
 

--- a/src/Operator/NotLike/NotLikeSymbolQueryLanguageOperator.php
+++ b/src/Operator/NotLike/NotLikeSymbolQueryLanguageOperator.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\NotLike;
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperator;
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageOperatorParserCreator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use Ferno\Loco\ConcParser;
 use Ferno\Loco\GrammarException;
 use Ferno\Loco\MonoParser;
@@ -39,7 +40,7 @@ class NotLikeSymbolQueryLanguageOperator implements QueryLanguageOperator
     }
 
 
-    public function createFieldExpressionParser(QueryLanguageField $field): MonoParser
+    public function createFieldExpressionParser(QueryLanguageField $field, QueryParserContext $context): MonoParser
     {
         assert($field instanceof QueryLanguageFieldSupportingNotLikeSymbolOperator);
 
@@ -49,7 +50,7 @@ class NotLikeSymbolQueryLanguageOperator implements QueryLanguageOperator
                 self::OPERATOR_IDENTIFIER,
                 $field->getSingleValueParserIdentifier(),
             ],
-            static fn($identifier, $operator, $value) => $field->createNotLikeSymbolOperatorOutput($identifier, $value),
+            static fn($identifier, $operator, $value) => $field->createNotLikeSymbolOperatorOutput($identifier, $value, $context),
         );
     }
 }

--- a/src/Operator/NotLike/NotLikeSymbolQueryLanguageOperatorTest.php
+++ b/src/Operator/NotLike/NotLikeSymbolQueryLanguageOperatorTest.php
@@ -5,6 +5,7 @@ namespace BrandEmbassy\QueryLanguageParser\Operator\NotLike;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarBrandLikeFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\NotFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\QueryLanguage\CarQueryParserFactory;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -24,7 +25,7 @@ class NotLikeSymbolQueryLanguageOperatorTest extends TestCase
     {
         $parser = (new CarQueryParserFactory())->create();
 
-        $result = $parser->parse($query);
+        $result = $parser->parse($query, new QueryParserContext());
 
         assert($result instanceof NotFilter);
 

--- a/src/Operator/NotLike/QueryLanguageFieldSupportingNotLikeOperator.php
+++ b/src/Operator/NotLike/QueryLanguageFieldSupportingNotLikeOperator.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassy\QueryLanguageParser\Operator\NotLike;
 
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageFieldSupportingSingleValueOperator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 
 interface QueryLanguageFieldSupportingNotLikeOperator extends QueryLanguageFieldSupportingSingleValueOperator
 {
@@ -12,5 +13,5 @@ interface QueryLanguageFieldSupportingNotLikeOperator extends QueryLanguageField
      *
      * @return mixed
      */
-    public function createNotLikeOperatorOutput($fieldName, $value);
+    public function createNotLikeOperatorOutput($fieldName, $value, QueryParserContext $context);
 }

--- a/src/Operator/NotLike/QueryLanguageFieldSupportingNotLikeSymbolOperator.php
+++ b/src/Operator/NotLike/QueryLanguageFieldSupportingNotLikeSymbolOperator.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassy\QueryLanguageParser\Operator\NotLike;
 
 use BrandEmbassy\QueryLanguageParser\Operator\QueryLanguageFieldSupportingSingleValueOperator;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 
 interface QueryLanguageFieldSupportingNotLikeSymbolOperator extends QueryLanguageFieldSupportingSingleValueOperator
 {
@@ -12,5 +13,5 @@ interface QueryLanguageFieldSupportingNotLikeSymbolOperator extends QueryLanguag
      *
      * @return mixed
      */
-    public function createNotLikeSymbolOperatorOutput($fieldName, $value);
+    public function createNotLikeSymbolOperatorOutput($fieldName, $value, QueryParserContext $context);
 }

--- a/src/Operator/QueryLanguageOperator.php
+++ b/src/Operator/QueryLanguageOperator.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassy\QueryLanguageParser\Operator;
 
 use BrandEmbassy\QueryLanguageParser\Field\QueryLanguageField;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use Ferno\Loco\MonoParser;
 
 interface QueryLanguageOperator
@@ -16,5 +17,5 @@ interface QueryLanguageOperator
     public function isFieldSupported(QueryLanguageField $field): bool;
 
 
-    public function createFieldExpressionParser(QueryLanguageField $field): MonoParser;
+    public function createFieldExpressionParser(QueryLanguageField $field, QueryParserContext $context): MonoParser;
 }

--- a/src/QueryParser.php
+++ b/src/QueryParser.php
@@ -31,14 +31,14 @@ class QueryParser
      *
      * @throws UnableToParseQueryException
      */
-    public function parse(string $query)
+    public function parse(string $query, QueryParserContext $context)
     {
         $fields = $this->grammarConfiguration->getFields();
         $operators = $this->grammarConfiguration->getOperators();
         $valueOnlyFilterFactory = $this->grammarConfiguration->getValueOnlyFilterFactory();
 
         try {
-            $grammar = $this->grammarFactory->create($fields, $operators, $valueOnlyFilterFactory);
+            $grammar = $this->grammarFactory->create($fields, $operators, $context, $valueOnlyFilterFactory);
 
             return $grammar->parse($query);
         } catch (GrammarException | ParseFailureException $e) {

--- a/src/QueryParserContext.php
+++ b/src/QueryParserContext.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassy\QueryLanguageParser;
+
+use function serialize;
+
+class QueryParserContext
+{
+    /**
+     * @var array<string, scalar>
+     */
+    private array $context = [];
+
+
+    /**
+     * @return scalar|null
+     */
+    public function get(string $key)
+    {
+        return $this->context[$key] ?? null;
+    }
+
+
+    /**
+     * @param scalar $value
+     */
+    public function set(string $key, $value): void
+    {
+        $this->context[$key] = $value;
+    }
+
+
+    public function remove(string $key): void
+    {
+        if (isset($this->context[$key])) {
+            unset($this->context[$key]);
+        }
+    }
+
+
+    public function toString(): string
+    {
+        return serialize($this->context);
+    }
+}

--- a/src/QueryParserTest.php
+++ b/src/QueryParserTest.php
@@ -9,6 +9,7 @@ use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarColorFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarColorLikeFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarHasColorFilter;
+use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarNumberOfDoorsFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\NotFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\OrFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\QueryLanguage\CarQueryParserFactory;
@@ -36,7 +37,7 @@ class QueryParserTest extends TestCase
     ): void {
         $parser = $this->createQueryParser($useValueOnlyFilter);
 
-        $actualFilter = $parser->parse($query);
+        $actualFilter = $parser->parse($query, new QueryParserContext());
 
         $expectedFilterMatcher($actualFilter);
     }
@@ -70,6 +71,13 @@ class QueryParserTest extends TestCase
             ],
 
             'basic filter double quoted' => [
+                'expectedFilter' => function (?CarFilter $filter): void {
+                    $this->assertCarBrandFilter(['Alfa romeo'], $filter);
+                },
+                'query' => 'brand = "Alfa romeo"',
+            ],
+
+            'Query parser context is used' => [
                 'expectedFilter' => function (?CarFilter $filter): void {
                     $this->assertCarBrandFilter(['Alfa romeo'], $filter);
                 },
@@ -334,7 +342,7 @@ class QueryParserTest extends TestCase
     {
         $parser = $this->createQueryParser($useValueOnlyFilter);
 
-        $result = $parser->parse($query);
+        $result = $parser->parse($query, new QueryParserContext());
 
         Assert::assertInstanceOf(CarFilter::class, $result);
     }
@@ -378,6 +386,22 @@ class QueryParserTest extends TestCase
                 ];
             }
         }
+    }
+
+
+    /**
+     * @throws Throwable
+     */
+    public function testQueryParserIsUsingContext(): void
+    {
+        $parser = $this->createQueryParser(false);
+        $context = new QueryParserContext();
+        $context->set('number_of_doors_modifier', 3);
+
+        $parsedFilter = $parser->parse('numberOfDoors = 5', $context);
+
+        Assert::assertInstanceOf(CarNumberOfDoorsFilter::class, $parsedFilter);
+        Assert::assertSame([8], $parsedFilter->getNumberOfDoors());
     }
 
 

--- a/src/Value/MultipleValuesExpressionParserCreatorTest.php
+++ b/src/Value/MultipleValuesExpressionParserCreatorTest.php
@@ -4,6 +4,7 @@ namespace BrandEmbassy\QueryLanguageParser\Value;
 
 use BrandEmbassy\QueryLanguageParser\Examples\Car\Filters\CarBrandFilter;
 use BrandEmbassy\QueryLanguageParser\Examples\Car\QueryLanguage\CarQueryParserFactory;
+use BrandEmbassy\QueryLanguageParser\QueryParserContext;
 use BrandEmbassy\QueryLanguageParser\UnableToParseQueryException;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
@@ -29,7 +30,7 @@ class MultipleValuesExpressionParserCreatorTest extends TestCase
         $parser = (new CarQueryParserFactory())->create();
         $valueToParse = 'brand IN ' . $multipleValueExpression;
 
-        $result = $parser->parse($valueToParse);
+        $result = $parser->parse($valueToParse, new QueryParserContext());
 
         assert($result instanceof CarBrandFilter);
         Assert::assertSame($expectedValues, $result->getBrands());
@@ -80,7 +81,7 @@ class MultipleValuesExpressionParserCreatorTest extends TestCase
 
         $this->expectException(UnableToParseQueryException::class);
 
-        $parser->parse($valueToParse);
+        $parser->parse($valueToParse, new QueryParserContext());
     }
 
 


### PR DESCRIPTION
I need to pass some IDs to additional preprocessing procedure in filter factories, e.g. `\BrandEmbassy\QueryLanguageParser\Operator\EqualTo\QueryLanguageFieldSupportingEqualToOperator::createEqualToOperatorOutput`